### PR TITLE
Add workaround for Debian & debian based distros

### DIFF
--- a/docs/Known-issues.md
+++ b/docs/Known-issues.md
@@ -68,6 +68,8 @@ This document lists known issues and their workarounds. For the latest updates, 
 ### Unsupported Distributions
 **Issue:** Bazzite, Linux Mint, Zorin OS, Manjaro, Ubuntu, Pop!_OS, and Debian are not officially supported.
 
+**Workaround for Debian/Ubuntu/Pop!_OS/Zorin OS/Linux Mint:** Install .NET 10 using [Microsoft's instructions](https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian?tabs=dotnet10), then run the Python installer as normal.
+
 **Workaround:** Use the [AppImage installer](../INSTALLATION.md#1-appimage-recommended-for-beginners) instead. See [System Requirements](SYSTEM-REQUIREMENTS.md) for details.
 
 **Workaround:** Use the [AppImage installer](../INSTALLATION.md#1-appimage-recommended-for-beginners) instead.


### PR DESCRIPTION
Adds mention of a workaround by installing .NET 10 from Microsoft's repository using their official instructions. 
Tested to install fine on Debian forky/unstable, despite the repo being for Debian 13 (trixie, stable)
