### PR TITLE
Fix Fedora PyQt6 dependency installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo pacman -S python-pyqt6
 
 **Fedora/Nobara:**
 ```bash
-sudo dnf install python3-pyqt6 python3-pyqt6-svg
+sudo dnf install python3-pyqt6
 ```
 
 **openSUSE (Tumbleweed/Leap):**


### PR DESCRIPTION
## Fix Fedora PyQt6 dependency installation

Fedora and other RHEL-based distributions bundle the QtSvg module directly inside the base `python3-pyqt6` package.

The README currently references:

```bash
sudo dnf install python3-pyqt6 python3-pyqt6-svg
```

However, `python3-pyqt6-svg` is not provided as a separate Fedora package. The `QtSvg` and `QtSvgWidgets` modules are already included in `python3-pyqt6`.

### Change

```diff
- sudo dnf install python3-pyqt6 python3-pyqt6-svg
+ sudo dnf install python3-pyqt6
```

Ubuntu/Debian instructions remain unchanged because `python3-pyqt6.qtsvg` is still distributed as a separate package there.