### PR TITLE
Fix Wayland image and file clipboard paste in Affinity

### DIFF
--- a/AffinityScripts/AffinityClipboardBridge.py
+++ b/AffinityScripts/AffinityClipboardBridge.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Bridge binary clipboard formats from Wayland to X11 for Wine applications.
+
+The daemon is event-driven via ``wl-paste --watch``. It mirrors copied image
+pixels (``image/png``) and copied file lists (``text/uri-list``), while keeping
+all payload handling binary-safe and bounded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import os
+from pathlib import Path
+import selectors
+import shutil
+import subprocess
+import sys
+import time
+from typing import Optional
+
+DEFAULT_MAX_BYTES = 256 * 1024 * 1024
+MAX_TYPES_BYTES = 64 * 1024
+READ_TIMEOUT_SECONDS = 5.0
+PRIORITY = ("text/uri-list", "image/png")
+
+
+def command_path(name: str) -> str:
+    path = shutil.which(name)
+    if path is None:
+        raise RuntimeError(f"Required command not found: {name}")
+    return path
+
+
+def runtime_paths() -> tuple[Path, Path]:
+    runtime_dir = Path(os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"))
+    return (
+        runtime_dir / "affinity-clipboard-bridge.digest",
+        runtime_dir / "affinity-clipboard-bridge.lock",
+    )
+
+
+def read_bounded(
+    args: list[str],
+    max_bytes: int,
+    timeout: float = READ_TIMEOUT_SECONDS,
+) -> tuple[Optional[bytes], str]:
+    """Read command output without allowing unbounded memory growth."""
+    process = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    assert process.stdout is not None
+    fd = process.stdout.fileno()
+    os.set_blocking(fd, False)
+    selector = selectors.DefaultSelector()
+    selector.register(fd, selectors.EVENT_READ)
+    payload = bytearray()
+    deadline = time.monotonic() + timeout
+
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                process.kill()
+                process.wait()
+                return None, "timeout"
+
+            events = selector.select(remaining)
+            if not events:
+                process.kill()
+                process.wait()
+                return None, "timeout"
+
+            chunk = os.read(fd, min(64 * 1024, max_bytes + 1 - len(payload)))
+            if not chunk:
+                return_code = process.wait(timeout=max(0.1, remaining))
+                if return_code != 0:
+                    return None, "read-failed"
+                return bytes(payload), "ok"
+
+            payload.extend(chunk)
+            if len(payload) > max_bytes:
+                process.kill()
+                process.wait()
+                return None, "too-large"
+    finally:
+        selector.close()
+        process.stdout.close()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+
+def get_types(wl_paste: str) -> set[str]:
+    payload, status = read_bounded(
+        [wl_paste, "--list-types"], MAX_TYPES_BYTES, timeout=2.0
+    )
+    if status != "ok" or payload is None:
+        return set()
+    return {
+        line.decode("utf-8", "replace").strip()
+        for line in payload.splitlines()
+        if line.strip()
+    }
+
+
+def normalize_payload(mime: str, payload: bytes) -> Optional[bytes]:
+    if mime != "text/uri-list":
+        return payload or None
+
+    # Xwayland/Klipper may append another newline whenever a selection crosses
+    # the Wayland/X11 boundary. Canonical CRLF keeps the digest stable.
+    normalized = payload.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    lines = [
+        line.strip()
+        for line in normalized.split(b"\n")
+        if line.strip() and not line.lstrip().startswith(b"#")
+    ]
+    if not lines:
+        return None
+    return b"\r\n".join(lines) + b"\r\n"
+
+
+def set_x11_clipboard(xclip: str, mime: str, payload: bytes) -> bool:
+    result = subprocess.run(
+        [xclip, "-selection", "clipboard", "-t", mime, "-in"],
+        input=payload,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=5.0,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def read_cached_digest(path: Path) -> Optional[bytes]:
+    try:
+        value = bytes.fromhex(path.read_text(encoding="ascii").strip())
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    return value if len(value) == hashlib.sha256().digest_size else None
+
+
+def write_cached_digest(path: Path, digest: bytes) -> None:
+    temporary = path.with_suffix(f".tmp.{os.getpid()}")
+    temporary.write_text(digest.hex(), encoding="ascii")
+    os.replace(temporary, path)
+
+
+def clear_cached_digest(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def process_current_selection(
+    wl_paste: str,
+    xclip: str,
+    max_bytes: int,
+    digest_path: Path,
+) -> str:
+    types = get_types(wl_paste)
+    mime = next((candidate for candidate in PRIORITY if candidate in types), None)
+    if mime is None:
+        clear_cached_digest(digest_path)
+        return "no-relevant-format"
+
+    payload, status = read_bounded([wl_paste, "--type", mime], max_bytes)
+    if status != "ok" or payload is None:
+        return status
+
+    payload = normalize_payload(mime, payload)
+    if payload is None:
+        return "empty"
+
+    digest = hashlib.sha256(mime.encode() + b"\0" + payload).digest()
+    if digest == read_cached_digest(digest_path):
+        return "unchanged"
+
+    if not set_x11_clipboard(xclip, mime, payload):
+        return "xclip-failed"
+
+    write_cached_digest(digest_path, digest)
+    print(f"mirrored {mime}: {len(payload)} bytes", flush=True)
+    return "mirrored"
+
+
+def event_main(max_bytes: int) -> int:
+    # wl-paste --watch offers the selected payload on stdin. Detach that pipe so
+    # a large selection is not transferred twice, but keep file descriptor 0
+    # open: wl-clipboard deliberately aborts when launched with a closed stdio
+    # descriptor.
+    devnull = os.open(os.devnull, os.O_RDONLY)
+    try:
+        os.dup2(devnull, sys.stdin.fileno())
+    finally:
+        if devnull != sys.stdin.fileno():
+            os.close(devnull)
+
+    digest_path, lock_path = runtime_paths()
+    try:
+        wl_paste = command_path("wl-paste")
+        xclip = command_path("xclip")
+        with lock_path.open("a+b") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            status = process_current_selection(
+                wl_paste, xclip, max_bytes, digest_path
+            )
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"clipboard bridge warning: {exc}", file=sys.stderr, flush=True)
+        return 0  # Do not terminate the parent wl-paste watcher.
+
+    if status not in {"mirrored", "unchanged", "no-relevant-format"}:
+        print(f"clipboard bridge warning: {status}", file=sys.stderr, flush=True)
+    return 0
+
+
+def watch_main(wl_paste: str, max_bytes: int) -> int:
+    digest_path, _ = runtime_paths()
+    clear_cached_digest(digest_path)
+    command = [
+        wl_paste,
+        "--watch",
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--event",
+        "--max-bytes",
+        str(max_bytes),
+    ]
+    subprocess.run(command, check=False)
+    # A watcher is expected to live until systemd stops the cgroup. Any normal
+    # return here is unexpected and should trigger Restart=on-failure.
+    return 1
+
+
+def once_main(wl_paste: str, xclip: str, max_bytes: int) -> int:
+    digest_path, lock_path = runtime_paths()
+    try:
+        with lock_path.open("a+b") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            # One-shot mode must verify a real X11 write rather than trusting a
+            # digest left by a daemon or an earlier invocation.
+            clear_cached_digest(digest_path)
+            status = process_current_selection(
+                wl_paste, xclip, max_bytes, digest_path
+            )
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"clipboard bridge error: {exc}", file=sys.stderr)
+        return 1
+
+    if status in {"mirrored", "unchanged"}:
+        return 0
+    print(f"clipboard bridge error: {status}", file=sys.stderr)
+    return 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--once", action="store_true", help="mirror once and exit")
+    mode.add_argument("--event", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=DEFAULT_MAX_BYTES,
+        help=f"maximum payload size (default: {DEFAULT_MAX_BYTES} bytes)",
+    )
+    args = parser.parse_args()
+    if args.max_bytes < 1:
+        parser.error("--max-bytes must be positive")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    if not os.environ.get("WAYLAND_DISPLAY"):
+        print("WAYLAND_DISPLAY is not set; this bridge requires Wayland", file=sys.stderr)
+        return 2
+    if not os.environ.get("DISPLAY"):
+        print("DISPLAY is not set; no Xwayland display is available", file=sys.stderr)
+        return 2
+
+    if args.event:
+        return event_main(args.max_bytes)
+
+    try:
+        wl_paste = command_path("wl-paste")
+        xclip = command_path("xclip")
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 2
+
+    if args.once:
+        return once_main(wl_paste, xclip, args.max_bytes)
+    return watch_main(wl_paste, args.max_bytes)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AffinityScripts/affinity-clipboard-bridge.service
+++ b/AffinityScripts/affinity-clipboard-bridge.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Binary-safe Wayland to X11 clipboard bridge for Affinity/Wine
+Documentation=https://github.com/ryzendew/Linux-Affinity-Installer/blob/main/docs/WAYLAND-CLIPBOARD.md
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 %h/.local/bin/affinity-clipboard-bridge.py
+Restart=on-failure
+RestartPreventExitStatus=2
+RestartSec=2
+
+[Install]
+WantedBy=graphical-session.target

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ sudo apt install python3-pyqt6.qtsvg
 - **[Wine Versions](docs/WINE-VERSIONS.md)** - Available Wine versions and recommendations
 - **[Hardware Acceleration](docs/HARDWARE-ACCELERATION.md)** - GPU acceleration options (vkd3d-proton, DXVK, OpenCL)
 - **[OpenCL Guide](docs/OpenCL-Guide.md)** - Detailed OpenCL configuration
+- **[Wayland Clipboard](docs/WAYLAND-CLIPBOARD.md)** - Paste copied images and files into Wine/Affinity
 - **[Legacy Scripts](docs/LEGACY-SCRIPTS.md)** - Command-line installation scripts
 
 ### Additional Resources

--- a/docs/Known-issues.md
+++ b/docs/Known-issues.md
@@ -95,6 +95,11 @@ This document lists known issues and their workarounds. For the latest updates, 
 
 ## Application Features
 
+### Copied Images or Files Cannot Be Pasted on Wayland
+**Issue:** Plain text pastes into Affinity, but copied image pixels (`image/png`) or files (`text/uri-list`) do not. This affects Wine using `winex11.drv` through Xwayland.
+
+**Workaround:** Install the bounded, binary-safe clipboard bridge described in the [Wayland Clipboard Guide](WAYLAND-CLIPBOARD.md). It mirrors only the missing image/file formats. Read the documented multi-format selection trade-off before enabling it.
+
 ### Microsoft Edge WebView2 Runtime Not Working
 **Issue:** The Microsoft Edge WebView2 Runtime is broken and does not work properly in Wine. This affects features in Affinity v3 that rely on WebView2, such as the Help system and some web-based dialogs.
 

--- a/docs/WAYLAND-CLIPBOARD.md
+++ b/docs/WAYLAND-CLIPBOARD.md
@@ -1,0 +1,186 @@
+# Wayland Clipboard: Paste Images and Files into Affinity
+
+## Symptom
+
+On a Wayland desktop, text can be copied into Affinity, but either of these fails:
+
+- copying pixels from Spectacle, a browser, or an image editor and pressing `Ctrl+V` in Affinity;
+- copying a PNG or another file in a Wayland file manager and pressing `Ctrl+V` in Affinity.
+
+This workaround applies when Affinity runs through Wine's `winex11.drv` on Xwayland.
+
+## Why it happens
+
+The clipboard has different formats for different operations:
+
+| Copy operation | Wayland MIME type | Wine/Windows format |
+| --- | --- | --- |
+| Plain text | `text/plain` | `CF_UNICODETEXT` |
+| Copied file(s) | `text/uri-list` | `CF_HDROP` |
+| Copied image pixels | `image/png` | registered `PNG` format |
+
+KDE/Klipper and Xwayland generally synchronize plain text, but may drop `text/uri-list` and `image/png` on the Wayland-to-X11 path. Wine never receives those formats, so Affinity has nothing useful to paste.
+
+`winewayland.drv` can theoretically avoid Xwayland, but it currently causes dead clipboard or rendering issues on some ElementalWarrior Wine/Affinity setups. The bridge below keeps the known-working X11 graphics path and mirrors only the missing clipboard formats.
+
+## Requirements
+
+Install `wl-clipboard`, `xclip`, and Python 3.
+
+### Arch, Artix, CachyOS, EndeavourOS
+
+```bash
+sudo pacman -S wl-clipboard xclip python
+```
+
+### Fedora or Nobara
+
+```bash
+sudo dnf install wl-clipboard xclip python3
+```
+
+### Ubuntu, Debian, Linux Mint, Pop!_OS, Zorin OS
+
+```bash
+sudo apt install wl-clipboard xclip python3
+```
+
+### openSUSE
+
+```bash
+sudo zypper install wl-clipboard xclip python3
+```
+
+## Install the bridge
+
+```bash
+mkdir -p ~/.local/bin ~/.config/systemd/user
+curl -fsSL \
+  https://raw.githubusercontent.com/ryzendew/Linux-Affinity-Installer/main/AffinityScripts/AffinityClipboardBridge.py \
+  -o ~/.local/bin/affinity-clipboard-bridge.py
+curl -fsSL \
+  https://raw.githubusercontent.com/ryzendew/Linux-Affinity-Installer/main/AffinityScripts/affinity-clipboard-bridge.service \
+  -o ~/.config/systemd/user/affinity-clipboard-bridge.service
+chmod 700 ~/.local/bin/affinity-clipboard-bridge.py
+systemctl --user daemon-reload
+systemctl --user enable --now affinity-clipboard-bridge.service
+```
+
+Check that it is running:
+
+```bash
+systemctl --user status affinity-clipboard-bridge.service
+journalctl --user -u affinity-clipboard-bridge.service -f
+```
+
+On KDE Plasma and GNOME, `graphical-session.target` normally starts the service
+with `DISPLAY` and `WAYLAND_DISPLAY` already imported. Sway and Hyprland users
+must add the compositor-specific startup commands in
+[Troubleshooting](#wayland-display-or-display-is-not-set). The service restarts
+after transient failures, but not after a missing-session error (exit status 2).
+
+## What the bridge does
+
+- reacts to clipboard-change events via `wl-paste --watch` instead of polling;
+- mirrors only `image/png` and `text/uri-list` from Wayland to X11;
+- passes PNG data as raw bytes (no text conversion);
+- rejects payloads larger than 256 MiB before they can exhaust memory;
+- uses SHA-256 deduplication to prevent image feedback loops;
+- canonicalizes URI-list line endings to prevent a slow newline feedback loop;
+- does not change Wine, DXVK, VKD3D, or the Affinity prefix.
+
+The daemon does not mirror plain text. However, `xclip` becomes the X11
+selection owner for one MIME target. A source selection that originally exposed
+several formats can therefore be reduced to the mirrored image or URI-list
+target after Xwayland synchronizes it back. Disable the bridge if that trade-off
+conflicts with another clipboard workflow.
+
+Do not replace the script with a shell expression such as `content=$(wl-paste)`. Shell command substitution cannot preserve NUL bytes and corrupts PNG clipboard data.
+
+## Verify
+
+Copy image pixels in Spectacle and run:
+
+```bash
+wl-paste --list-types
+# Must include image/png
+
+wl-paste --type image/png | sha256sum
+xclip -selection clipboard -o -t image/png | sha256sum
+# Both hashes should match.
+```
+
+For a file copied in a Wayland file manager:
+
+```bash
+wl-paste --list-types
+# Must include text/uri-list
+
+xclip -selection clipboard -o -t TARGETS
+# Must include text/uri-list.
+```
+
+Finally, paste into Affinity. Clipboard format inspection alone does not prove that the application accepts the data.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now affinity-clipboard-bridge.service
+rm ~/.config/systemd/user/affinity-clipboard-bridge.service
+rm ~/.local/bin/affinity-clipboard-bridge.py
+systemctl --user daemon-reload
+```
+
+This removes only the bridge. It does not modify or remove Affinity or its Wine prefix.
+
+## Troubleshooting
+
+### Service exits with “Required command not found”
+
+Install both `wl-clipboard` and `xclip`, then restart the service:
+
+```bash
+systemctl --user restart affinity-clipboard-bridge.service
+```
+
+### `WAYLAND_DISPLAY` or `DISPLAY` is not set
+
+The systemd user manager must inherit the graphical-session environment. A
+manual repair for the current login is:
+
+```bash
+systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_RUNTIME_DIR
+systemctl --user restart affinity-clipboard-bridge.service
+```
+
+For Sway, make that persistent by adding these lines to the Sway config:
+
+```text
+exec systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_RUNTIME_DIR
+exec systemctl --user start affinity-clipboard-bridge.service
+```
+
+For Hyprland, add:
+
+```text
+exec-once = systemctl --user import-environment DISPLAY WAYLAND_DISPLAY XDG_RUNTIME_DIR
+exec-once = systemctl --user start affinity-clipboard-bridge.service
+```
+
+Other compositors need equivalent session-start commands. Verify the imported
+values with:
+
+```bash
+systemctl --user show-environment | grep -E '^(DISPLAY|WAYLAND_DISPLAY)='
+```
+
+### Payload is too large
+
+The default limit is 256 MiB. An oversized selection is rejected and logged as
+`too-large`. To choose a different bounded limit, add `--max-bytes BYTES` to the
+service's `ExecStart` line, run `systemctl --user daemon-reload`, and restart the
+service.
+
+### Text works but copied images do not
+
+Inspect `wl-paste --list-types`. A Spectacle pixel copy should offer `image/png`. Copying only a filename or path as text is a different operation and will not create image clipboard data.

--- a/tests/test_affinity_clipboard_bridge.py
+++ b/tests/test_affinity_clipboard_bridge.py
@@ -1,0 +1,154 @@
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "AffinityScripts"
+    / "AffinityClipboardBridge.py"
+)
+SPEC = importlib.util.spec_from_file_location("affinity_clipboard_bridge", SCRIPT)
+assert SPEC is not None
+assert SPEC.loader is not None
+bridge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bridge)
+
+
+class ClipboardBridgeTests(unittest.TestCase):
+    def test_read_bounded_preserves_binary_nul_bytes(self):
+        expected = b"\x89PNG\r\n\x1a\n\x00binary\x00payload"
+        code = f"import sys; sys.stdout.buffer.write({expected!r})"
+        payload, status = bridge.read_bounded(
+            [sys.executable, "-c", code], max_bytes=1024
+        )
+        self.assertEqual(status, "ok")
+        self.assertEqual(payload, expected)
+
+    def test_read_bounded_rejects_oversized_payload(self):
+        code = "import sys; sys.stdout.buffer.write(b'x' * 1025)"
+        payload, status = bridge.read_bounded(
+            [sys.executable, "-c", code], max_bytes=1024
+        )
+        self.assertIsNone(payload)
+        self.assertEqual(status, "too-large")
+
+    def test_read_bounded_times_out_nonterminating_source(self):
+        code = "import time; time.sleep(2)"
+        payload, status = bridge.read_bounded(
+            [sys.executable, "-c", code], max_bytes=1024, timeout=0.05
+        )
+        self.assertIsNone(payload)
+        self.assertEqual(status, "timeout")
+
+    def test_uri_list_has_one_canonical_terminator(self):
+        payload = b"# comment\nfile:///tmp/a.png\r\n\nfile:///tmp/b.png\n\n"
+        expected = b"file:///tmp/a.png\r\nfile:///tmp/b.png\r\n"
+        self.assertEqual(
+            bridge.normalize_payload("text/uri-list", payload), expected
+        )
+
+    def test_no_relevant_format_clears_cached_digest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            digest_path = Path(directory) / "digest"
+            digest_path.write_text("00" * 32)
+            with mock.patch.object(bridge, "get_types", return_value={"text/plain"}):
+                status = bridge.process_current_selection(
+                    "wl-paste", "xclip", 1024, digest_path
+                )
+            self.assertEqual(status, "no-relevant-format")
+            self.assertFalse(digest_path.exists())
+
+    def test_xclip_failure_is_not_cached(self):
+        with tempfile.TemporaryDirectory() as directory:
+            digest_path = Path(directory) / "digest"
+            with (
+                mock.patch.object(bridge, "get_types", return_value={"image/png"}),
+                mock.patch.object(
+                    bridge, "read_bounded", return_value=(b"PNG\x00data", "ok")
+                ),
+                mock.patch.object(bridge, "set_x11_clipboard", return_value=False),
+            ):
+                status = bridge.process_current_selection(
+                    "wl-paste", "xclip", 1024, digest_path
+                )
+            self.assertEqual(status, "xclip-failed")
+            self.assertFalse(digest_path.exists())
+
+    def test_event_helper_keeps_standard_input_descriptor_open(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            marker = root / "stdin-open"
+            wl_paste = root / "wl-paste"
+            wl_paste.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, pathlib, sys\n"
+                "os.fstat(0)\n"
+                f"pathlib.Path({str(marker)!r}).write_text('open')\n"
+                "if '--list-types' in sys.argv:\n"
+                "    print('text/plain')\n"
+            )
+            wl_paste.chmod(0o700)
+            xclip = root / "xclip"
+            xclip.write_text("#!/bin/sh\nexit 0\n")
+            xclip.chmod(0o700)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{root}:{environment['PATH']}",
+                    "DISPLAY": ":99",
+                    "WAYLAND_DISPLAY": "wayland-test",
+                    "XDG_RUNTIME_DIR": str(root),
+                }
+            )
+            result = subprocess.run(
+                [sys.executable, SCRIPT, "--event"],
+                input=b"watch payload that must be detached",
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(marker.read_text(), "open")
+
+    def test_once_returns_failure_for_failed_transfer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            paths = (Path(directory) / "digest", Path(directory) / "lock")
+            with (
+                mock.patch.object(bridge, "runtime_paths", return_value=paths),
+                mock.patch.object(
+                    bridge,
+                    "process_current_selection",
+                    return_value="xclip-failed",
+                ),
+            ):
+                self.assertEqual(bridge.once_main("wl-paste", "xclip", 1024), 1)
+
+    def test_once_returns_success_only_after_fresh_transfer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            paths = (Path(directory) / "digest", Path(directory) / "lock")
+            paths[0].write_text("00" * 32)
+
+            def fresh_transfer(*_args):
+                self.assertFalse(paths[0].exists())
+                return "mirrored"
+
+            with (
+                mock.patch.object(bridge, "runtime_paths", return_value=paths),
+                mock.patch.object(
+                    bridge,
+                    "process_current_selection",
+                    side_effect=fresh_transfer,
+                ),
+            ):
+                self.assertEqual(bridge.once_main("wl-paste", "xclip", 1024), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a binary-safe Wayland → X11 clipboard bridge for Affinity/Wine
- mirror only `image/png` (copied pixels) and `text/uri-list` (copied files)
- process selection-change events instead of repeatedly polling full payloads
- bound each payload to 256 MiB and report reliable one-shot exit status
- document the single-target `xclip` trade-off and compositor-specific systemd startup
- add an optional systemd user service and complete install/verify/uninstall documentation
- document the workaround in README and Known Issues

## Root cause

With Affinity running through Wine's `winex11.drv`, KDE/Wayland can synchronize plain text while dropping non-text formats on the Wayland-to-X11 path. Affinity then has no image or file format available to paste.

Two implementation details are important:

1. PNG data must never pass through shell command substitution (`content=$(...)`), because NUL bytes are lost and the image is corrupted.
2. `text/uri-list` is canonicalized to one CRLF terminator. Otherwise the X11→Wayland return path can append one newline per round trip and create a slow feedback loop.

The bridge therefore keeps payloads as Python `bytes`, uses a fixed MIME allowlist, and deduplicates with SHA-256.

## Scope

This is an opt-in workaround. It does not automatically alter the installer, Wine prefix, graphics driver, DXVK, or VKD3D configuration.

## Tested

Environment:

- CachyOS / KDE Plasma 6 / Wayland
- Affinity 3.2.2.4557
- ElementalWarrior Wine 11.12 using `winex11.drv`

Checks performed:

- copied Spectacle PNG pasted successfully into Affinity
- Wayland and X11 PNG SHA-256 hashes matched byte-for-byte
- `text/uri-list` arrived on X11 and URI line endings remained stable without a feedback loop
- normal text selections are not mirrored and clear the deduplication cache
- event helper keeps stdin valid for `wl-clipboard` while detaching watch payloads
- oversized and nonterminating selection sources are rejected
- failed `xclip` writes produce a failing `--once` exit status and are not cached
- 9 standard-library regression tests pass
- `python3 -m py_compile AffinityScripts/AffinityClipboardBridge.py`
- `systemd-analyze --user verify AffinityScripts/affinity-clipboard-bridge.service`
- `git diff --check`
