### PR TITLE
fix(install): fix Zorin OS install and Wine runtime launch path

### DIFF
--- a/AffinityScripts/AffinityLinuxInstaller.py
+++ b/AffinityScripts/AffinityLinuxInstaller.py
@@ -669,6 +669,7 @@ class AffinityInstallerGUI(QMainWindow):
                 ("dotnet35sp1", ".NET Framework 3.5 SP1"),
                 ("dotnet48", ".NET Framework 4.8"),
                 ("corefonts", "Windows Core Fonts"),
+                ("allfonts", "Segoe UI Fonts (allfonts)"),
                 ("vcrun2022", "Visual C++ Redistributables 2022"),
                 ("msxml3", "MSXML 3.0"),
                 ("msxml6", "MSXML 6.0"),
@@ -709,8 +710,7 @@ class AffinityInstallerGUI(QMainWindow):
             if button is None:
                 continue
 
-            is_installed = app_status.get(app_name, False)
-            enabled = wine_exists and is_installed
+            enabled = wine_exists
 
             button.setEnabled(enabled)
             if enabled:
@@ -5656,6 +5656,7 @@ class AffinityInstallerGUI(QMainWindow):
         """Execute command and stream output to log in real-time, cancellable.
         Also stores the full streamed text in self._last_stream_output_text for post-run heuristics."""
         self._last_stream_output_text = ""
+        self._last_stream_returncode = None
         try:
             if isinstance(command, str):
                 command = command.split()
@@ -5752,6 +5753,7 @@ class AffinityInstallerGUI(QMainWindow):
 
             process.wait()
             self._last_stream_output_text = "".join(buffer)
+            self._last_stream_returncode = process.returncode
             return process.returncode == 0
         except Exception as e:
             self.log(f"Error running command: {e}", "error")
@@ -5825,6 +5827,47 @@ class AffinityInstallerGUI(QMainWindow):
             pass
         return False
 
+    def _affinity_app_paths(self, display_name):
+        """Return (dir_name, exe_name) for the Affinity app referenced by display_name.
+        Falls back to the unified app when the name is unrecognized."""
+        name = (display_name or "").lower()
+        if "photo" in name:
+            return ("Photo 2", "Photo.exe")
+        if "designer" in name:
+            return ("Designer 2", "Designer.exe")
+        if "publisher" in name:
+            return ("Publisher 2", "Publisher.exe")
+        # Unified / Affinity v3 / Suite
+        return ("Affinity", "Affinity.exe")
+
+    def verify_affinity_artifacts(self, display_name):
+        """Verify the real Affinity payload was laid down after an installer run.
+        Returns True only when the app executable (or Serif.Affinity.dll for the
+        unified app) actually exists on disk. Logs which artifacts were checked."""
+        dir_name, exe_name = self._affinity_app_paths(display_name)
+        app_dir = (
+            Path(self.directory)
+            / "drive_c"
+            / "Program Files"
+            / "Affinity"
+            / dir_name
+        )
+        candidates = [app_dir / exe_name]
+        # The unified app also ships Serif.Affinity.dll; accept either.
+        name = (display_name or "").lower()
+        if "photo" not in name and "designer" not in name and "publisher" not in name:
+            candidates.append(app_dir / "Serif.Affinity.dll")
+
+        for artifact in candidates:
+            if artifact.exists():
+                self.log(f"Verified install artifact present: {artifact}", "success")
+                return True
+
+        self.log("Installation verification failed. Expected at least one of:", "error")
+        for artifact in candidates:
+            self.log(f"  missing: {artifact}", "error")
+        return False
+
     def _run_installer_and_capture(
         self, installer_file: Path, env: dict, label: str = "installer"
     ):
@@ -5847,26 +5890,34 @@ class AffinityInstallerGUI(QMainWindow):
         )
         is_webview2 = "webview" in installer_name or "edge" in installer_name
 
+        # Select Wine binary for this installer
+        if is_affinity_v3 or is_affinity_v2:
+            wine = self.get_wine_tkg_for_installer("wine")
+            winecfg = self.get_wine_tkg_for_installer("winecfg")
+            self.log(f"Using Wine for Affinity installation: {wine}", "info")
+        elif is_webview2:
+            wine = self.get_wine_tkg_for_installer("wine")
+            winecfg = self.get_wine_tkg_for_installer("winecfg")
+            self.log(f"Using Wine for WebView2 installation: {wine}", "info")
+        else:
+            wine = str(self.get_wine_path("wine"))
+            winecfg = str(self.get_wine_path("winecfg"))
+
+        # Ensure selected Wine directory is first in PATH for wineserver/wineboot helpers
+        try:
+            wine_parent = str(Path(wine).parent)
+            current_path = env.get("PATH", "")
+            env["PATH"] = f"{wine_parent}:{current_path}"
+        except Exception:
+            pass
+
         # Set Windows 11 before installing Affinity
         if is_affinity_v3 or is_affinity_v2:
             self.log(
                 "Setting Windows version to 11 before Affinity installation...", "info"
             )
-            # Use system winecfg for Affinity installers (they use system wine)
-            self.run_command(["winecfg", "-v", "win11"], check=False, env=env)
+            self.run_command([winecfg, "-v", "win11"], check=False, env=env)
             self.log("✓ Windows version set to 11", "success")
-
-        # Use system Wine for Affinity installations (custom Wine doesn't work for installation)
-        if is_affinity_v3 or is_affinity_v2:
-            wine = "wine"  # Use system Wine for installation
-            self.log("Using system Wine for Affinity installation", "info")
-        elif is_webview2:
-            # Use system wine for WebView2
-            wine = "wine"
-            self.log("Using system Wine for WebView2 installation", "info")
-        else:
-            # Use custom Wine for other installers
-            wine = str(self.get_wine_path("wine"))
 
         # For Affinity installers, try direct execution first (more reliable)
         if is_affinity_v3 or is_affinity_v2:
@@ -5886,6 +5937,25 @@ class AffinityInstallerGUI(QMainWindow):
                 t0 = time.time()
                 ok = self.run_command_streaming(cmd, env=env)
                 dt = time.time() - t0
+
+                rc = getattr(self, "_last_stream_returncode", None)
+                self.log(
+                    f"{label.capitalize()} attempt {idx} exit code={rc}, elapsed={dt:.2f}s",
+                    "info",
+                )
+                # For Affinity installers, dump full installer output to help
+                # diagnose crashes (e.g. .NET 0xe0434352 in SetupUI.exe).
+                if is_affinity_v3 or is_affinity_v2:
+                    full_out = (self._last_stream_output_text or "").strip()
+                    if full_out:
+                        self.log(
+                            f"--- Full {label} output (attempt {idx}) ---", "info"
+                        )
+                        for out_line in full_out.splitlines():
+                            self.log(f"  {out_line}", "info")
+                        self.log(
+                            f"--- End {label} output (attempt {idx}) ---", "info"
+                        )
 
                 # For Affinity installers, check if installer is actually running despite exceptions
                 if is_affinity_v3 or is_affinity_v2:
@@ -7398,7 +7468,8 @@ class AffinityInstallerGUI(QMainWindow):
 
                                 # Extract app path
                                 quoted_path_match = re.search(
-                                    r'wine\s+"([^"]+)"', exec_content
+                                    r'wine\s+(?:start\s+/unix\s+)?"([^"]+)"',
+                                    exec_content,
                                 )
                                 if quoted_path_match:
                                     app_path = quoted_path_match.group(1)
@@ -7412,8 +7483,7 @@ class AffinityInstallerGUI(QMainWindow):
                                     )
 
                                 # Get wine path
-                                wine = self.get_wine_path("wine")
-                                wine_path = str(wine)
+                                wine_path = self.get_wine_tkg_for_installer("wine")
 
                                 # Get GPU environment variables (but NOT DXVK)
                                 gpu_env = self.get_gpu_env_vars()
@@ -7423,12 +7493,9 @@ class AffinityInstallerGUI(QMainWindow):
                                 exec_line = f"Exec=env WINEPREFIX={directory_str}"
                                 if gpu_env:
                                     exec_line += f" {gpu_env.strip()}"
-                                exec_line += f" {wine_path}"
+                                exec_line += f" {wine_path} start /unix"
                                 if app_path:
-                                    if " " in app_path or not app_path.startswith("/"):
-                                        exec_line += f' "{app_path}"'
-                                    else:
-                                        exec_line += f" {app_path}"
+                                    exec_line += f' "{app_path}"'
 
                                 new_lines.append(exec_line + "\n")
                                 exec_updated = True
@@ -7650,7 +7717,8 @@ class AffinityInstallerGUI(QMainWindow):
 
                                 # Extract app path
                                 quoted_path_match = re.search(
-                                    r'wine\s+"([^"]+)"', exec_content
+                                    r'wine\s+(?:start\s+/unix\s+)?"([^"]+)"',
+                                    exec_content,
                                 )
                                 if quoted_path_match:
                                     app_path = quoted_path_match.group(1)
@@ -7664,8 +7732,7 @@ class AffinityInstallerGUI(QMainWindow):
                                     )
 
                                 # Get wine path
-                                wine = self.get_wine_path("wine")
-                                wine_path = str(wine)
+                                wine_path = self.get_wine_tkg_for_installer("wine")
 
                                 # Get GPU and DXVK environment variables
                                 gpu_env = self.get_gpu_env_vars()
@@ -7678,12 +7745,9 @@ class AffinityInstallerGUI(QMainWindow):
                                     exec_line += f" {gpu_env.strip()}"
                                 if dxvk_env:
                                     exec_line += f" {dxvk_env.strip()}"
-                                exec_line += f" {wine_path}"
+                                exec_line += f" {wine_path} start /unix"
                                 if app_path:
-                                    if " " in app_path or not app_path.startswith("/"):
-                                        exec_line += f' "{app_path}"'
-                                    else:
-                                        exec_line += f" {app_path}"
+                                    exec_line += f' "{app_path}"'
 
                                 new_lines.append(exec_line + "\n")
                                 exec_updated = True
@@ -7771,8 +7835,9 @@ class AffinityInstallerGUI(QMainWindow):
                         exec_content = line[5:].strip()  # Remove "Exec=" prefix
 
                         # Use regex to extract the app path (everything after wine, typically in quotes or ending with .exe)
-                        # Pattern 1: Find app path in quotes after wine
-                        quoted_path_match = re.search(r'wine\s+"([^"]+)"', exec_content)
+                        quoted_path_match = re.search(
+                            r'wine\s+(?:start\s+/unix\s+)?"([^"]+)"', exec_content
+                        )
                         if quoted_path_match:
                             app_path = quoted_path_match.group(1)
                         else:
@@ -7786,8 +7851,7 @@ class AffinityInstallerGUI(QMainWindow):
                             )
 
                         # Get wine path (standard location)
-                        wine = self.get_wine_path("wine")
-                        wine_path = str(wine)
+                        wine_path = self.get_wine_tkg_for_installer("wine")
 
                         # Rebuild Exec line with new GPU env vars
                         exec_line = f"Exec=env WINEPREFIX={directory_str}"
@@ -7795,13 +7859,9 @@ class AffinityInstallerGUI(QMainWindow):
                             exec_line += f" {gpu_env.strip()}"
                         if dxvk_env:
                             exec_line += f" {dxvk_env.strip()}"
-                        exec_line += f" {wine_path}"
+                        exec_line += f" {wine_path} start /unix"
                         if app_path:
-                            # Quote the app path if it contains spaces or special characters
-                            if " " in app_path or not app_path.startswith("/"):
-                                exec_line += f' "{app_path}"'
-                            else:
-                                exec_line += f" {app_path}"
+                            exec_line += f' "{app_path}"'
                         else:
                             # If we couldn't parse app_path, log a warning but still update GPU env
                             self.log(
@@ -11193,16 +11253,119 @@ class AffinityInstallerGUI(QMainWindow):
         # Set up DLL overrides
         self.setup_d3d12_overrides()
 
+    def _find_vkd3d_dll_sources(self):
+        """Locate extracted vkd3d-proton DLLs on disk, returning a mapping of
+        {"x64": dir, "x86": dir} for whichever architectures were found.
+
+        The archive layout is <root>/x64/*.dll and <root>/x86/*.dll, but older
+        installs staged a flat copy of only the 64-bit DLLs into vkd3d_dlls/ and
+        into the Wine tree, so several locations are checked."""
+        dll_names = ("d3d12.dll", "d3d12core.dll")
+        sources = {}
+
+        cache_dir = Path(self.directory) / "dxvk"
+        candidate_roots = []
+        if cache_dir.exists():
+            candidate_roots.extend(sorted(cache_dir.glob("vkd3d-proton-*")))
+        candidate_roots.extend(sorted(Path(self.directory).glob("vkd3d-proton-*")))
+
+        for root in candidate_roots:
+            if not root.is_dir():
+                continue
+            for arch in ("x64", "x86"):
+                if arch in sources:
+                    continue
+                arch_dir = root / arch
+                if all((arch_dir / dll).exists() for dll in dll_names):
+                    sources[arch] = arch_dir
+
+        if "x64" not in sources:
+            for fallback in (
+                Path(self.directory) / "vkd3d_dlls",
+                self.get_wine_dir()
+                / "lib"
+                / "wine"
+                / "vkd3d-proton"
+                / "x86_64-windows",
+            ):
+                if all((fallback / dll).exists() for dll in dll_names):
+                    sources["x64"] = fallback
+                    break
+
+        return sources
+
+    def install_vkd3d_dlls_to_prefix(self):
+        """Copy the real vkd3d-proton d3d12/d3d12core DLLs into the Wine prefix's
+        system32 (64-bit) and syswow64 (32-bit) directories.
+
+        This is required because the d3d12/d3d12core DLL overrides are set to
+        "native" with no builtin fallback. Wine resolves "native" by loading the
+        DLL from the prefix's system directories, so if only Wine's own builtin
+        d3d12 is present there the load is refused and Wine reports
+        "Library d3d12.dll ... not found". That single failure cascades through
+        libdxcore -> libraster -> librenderer/libStory/libpsd/libpersona, and the
+        Affinity process then hangs instead of starting. Staging the DLLs into the
+        Wine installation tree alone is not sufficient."""
+        sources = self._find_vkd3d_dll_sources()
+        if not sources:
+            self.log(
+                "Warning: could not locate extracted vkd3d-proton DLLs to install into the prefix",
+                "warning",
+            )
+            return False
+
+        targets = {
+            "x64": Path(self.directory) / "drive_c" / "windows" / "system32",
+            "x86": Path(self.directory) / "drive_c" / "windows" / "syswow64",
+        }
+
+        installed = 0
+        for arch, target_dir in targets.items():
+            source_dir = sources.get(arch)
+            if not source_dir or not target_dir.exists():
+                continue
+            for dll in ("d3d12.dll", "d3d12core.dll"):
+                src = source_dir / dll
+                if not src.exists():
+                    continue
+                dest = target_dir / dll
+                try:
+                    backup = dest.with_suffix(dest.suffix + ".wine-builtin.bak")
+                    if dest.exists() and not backup.exists():
+                        shutil.copy2(dest, backup)
+                    shutil.copy2(src, dest)
+                    installed += 1
+                except Exception as e:
+                    self.log(
+                        f"Warning: could not install {dll} into {target_dir.name}: {e}",
+                        "warning",
+                    )
+
+        if installed:
+            self.log(
+                f"Installed {installed} vkd3d-proton DLL(s) into the Wine prefix",
+                "success",
+            )
+            return True
+
+        self.log(
+            "Warning: no vkd3d-proton DLLs were installed into the Wine prefix",
+            "warning",
+        )
+        return False
+
     def setup_d3d12_overrides(self):
         """Set up DLL overrides for d3d12.dll and d3d12core.dll"""
         self.log("Setting up DLL overrides for d3d12...", "info")
+
+        self.install_vkd3d_dlls_to_prefix()
 
         reg_file = Path(self.directory) / "dll_overrides.reg"
         with open(reg_file, "w") as f:
             f.write("REGEDIT4\n")
             f.write("[HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides]\n")
-            f.write('"d3d12"="native"\n')
-            f.write('"d3d12core"="native"\n')
+            f.write('"d3d12"="native,builtin"\n')
+            f.write('"d3d12core"="native,builtin"\n')
 
         regedit = self.get_wine_path("regedit")
         env = os.environ.copy()
@@ -11456,6 +11619,15 @@ class AffinityInstallerGUI(QMainWindow):
                         self.log(f"Copied {dll}", "success")
                         break
 
+            cache_dir = Path(self.directory) / "dxvk"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            cached_vkd3d_dir = cache_dir / f"vkd3d-proton-{vkd3d_version}"
+            if not cached_vkd3d_dir.exists():
+                try:
+                    shutil.copytree(vkd3d_dir, cached_vkd3d_dir)
+                except Exception as e:
+                    self.log(f"Warning: could not cache vkd3d-proton: {e}", "warning")
+
             shutil.rmtree(vkd3d_dir)
 
             # Store installed version
@@ -11514,6 +11686,14 @@ class AffinityInstallerGUI(QMainWindow):
             "renderer=vulkan",
             "crypt32",
         ]
+        if not self.has_segoe_ui_fonts():
+            components.append("allfonts")
+            self.log(
+                "Segoe UI fonts not found in prefix, adding allfonts installation",
+                "warning",
+            )
+        else:
+            self.log("Segoe UI fonts already present, skipping allfonts", "success")
 
         self.log(
             "Installing Wine components (this may take several minutes)...", "info"
@@ -12398,6 +12578,14 @@ Would you like to continue with {distro_name} anyway?"""
                 ("tahoma", "Tahoma Font"),
                 ("renderer=vulkan", "Vulkan Renderer"),
             ]
+            if not self.has_segoe_ui_fonts():
+                components.append(("allfonts", "Segoe UI Fonts (allfonts)"))
+                self.log(
+                    "Segoe UI fonts not found in prefix, adding allfonts installation",
+                    "warning",
+                )
+            else:
+                self.log("Segoe UI fonts already present, skipping allfonts", "success")
         except Exception as e:
             self.log(
                 f"Error in winetricks dependencies installation: {str(e)}", "error"
@@ -12972,6 +13160,21 @@ Would you like to continue with {distro_name} anyway?"""
             return None
         return None
 
+    def has_segoe_ui_fonts(self):
+        """Check whether the prefix has Segoe UI fonts required by WPF installers."""
+        fonts_dir = Path(self.directory) / "drive_c" / "windows" / "Fonts"
+        if not fonts_dir.exists():
+            return False
+
+        segoe_candidates = [
+            "segoeui.ttf",
+            "segoeuib.ttf",
+            "segoeuii.ttf",
+            "segoeuiz.ttf",
+            "seguili.ttf",
+        ]
+        return any((fonts_dir / font).exists() for font in segoe_candidates)
+
     def _check_winetricks_component(self, component, wine, env):
         """Check if a winetricks component is installed"""
         try:
@@ -13003,6 +13206,8 @@ Would you like to continue with {distro_name} anyway?"""
                     for font in core_fonts:
                         if (fonts_dir / font).exists():
                             return True
+            elif component == "allfonts":
+                return self.has_segoe_ui_fonts()
             elif component == "vcrun2022":
                 # Check for Visual C++ 2022 redistributables
                 vcrun_paths = [
@@ -13064,10 +13269,9 @@ Would you like to continue with {distro_name} anyway?"""
 
         return False
 
-    def check_webview2_installed(self):
-        """Check if WebView2 Runtime is already installed (fast check - file paths only)"""
-        # Fast check: only check file paths, skip slow registry query
-        webview2_paths = [
+    def _find_webview2_executable(self):
+        """Find msedgewebview2.exe in standard WebView2 install locations."""
+        webview2_roots = [
             Path(self.directory)
             / "drive_c"
             / "Program Files (x86)"
@@ -13082,19 +13286,26 @@ Would you like to continue with {distro_name} anyway?"""
             / "Application",
         ]
 
-        for webview2_path in webview2_paths:
-            if webview2_path.exists():
-                # Check if msedgewebview2.exe exists
-                msedgewebview2_exe = webview2_path / "msedgewebview2.exe"
-                if msedgewebview2_exe.exists():
-                    return True
+        for root in webview2_roots:
+            if not root.exists():
+                continue
 
-        # If file check fails, do a registry check (only if file check failed)
-        # Skip registry check to make it faster - file check is usually sufficient
-        # Registry check can be slow and may hang, so we skip it for speed
-        return False
+            direct_exe = root / "msedgewebview2.exe"
+            if direct_exe.exists():
+                return direct_exe
 
-        return False
+            for version_dir in sorted(root.iterdir(), reverse=True):
+                if not version_dir.is_dir():
+                    continue
+                candidate = version_dir / "msedgewebview2.exe"
+                if candidate.exists():
+                    return candidate
+
+        return None
+
+    def check_webview2_installed(self):
+        """Check if WebView2 Runtime is already installed."""
+        return self._find_webview2_executable() is not None
 
     def install_webview2_runtime(self):
         """Install Microsoft Edge WebView2 Runtime for Affinity v3 (Unified)"""
@@ -13165,30 +13376,10 @@ Would you like to continue with {distro_name} anyway?"""
         self.log("Checking if WebView2 Runtime is already installed...", "info")
         webview2_installed = False
 
-        # Check for WebView2 installation directory
-        webview2_paths = [
-            Path(self.directory)
-            / "drive_c"
-            / "Program Files (x86)"
-            / "Microsoft"
-            / "EdgeWebView"
-            / "Application",
-            Path(self.directory)
-            / "drive_c"
-            / "Program Files"
-            / "Microsoft"
-            / "EdgeWebView"
-            / "Application",
-        ]
-
-        for webview2_path in webview2_paths:
-            if webview2_path.exists():
-                # Check if msedgewebview2.exe exists
-                msedgewebview2_exe = webview2_path / "msedgewebview2.exe"
-                if msedgewebview2_exe.exists():
-                    webview2_installed = True
-                    self.log(f"WebView2 Runtime found at: {webview2_path}", "success")
-                    break
+        webview2_exe = self._find_webview2_executable()
+        if webview2_exe:
+            webview2_installed = True
+            self.log(f"WebView2 Runtime found at: {webview2_exe}", "success")
 
         # Also check registry for WebView2 installation
         if not webview2_installed:
@@ -14016,10 +14207,7 @@ Would you like to continue with {distro_name} anyway?"""
 
         desktop_file = desktop_dir / f"{app_name.replace(' ', '')}.desktop"
 
-        wine = self.get_wine_path("wine")
-
-        # Normalize all paths to strings to avoid double slashes
-        wine_str = str(wine)
+        wine_str = self.get_wine_tkg_for_installer("wine")
         directory_str = str(self.directory).rstrip(
             "/"
         )  # Remove trailing slash if present
@@ -14050,7 +14238,7 @@ Would you like to continue with {distro_name} anyway?"""
                 exec_line += f" {gpu_env.strip()}"
             if dxvk_env:
                 exec_line += f" {dxvk_env.strip()}"
-            exec_line += f' {wine_str} "{exe_path_normalized}"'
+            exec_line += f' {wine_str} start /unix "{exe_path_normalized}"'
             f.write(f"{exec_line}\n")
             f.write("Terminal=false\n")
             f.write("Type=Application\n")
@@ -14175,13 +14363,37 @@ Would you like to continue with {distro_name} anyway?"""
                 installer_file.unlink()
                 self.log("Installer file removed", "success")
 
-            # Remove Wine desktop entries created by the installer
-            desktop_dir = Path.home() / ".local" / "share" / "applications"
-            wine_desktop_dir = desktop_dir / "wine" / "Programs"
+            if self.check_cancelled():
+                self.log("Update cancelled.", "warning")
+                return
 
             # Ensure display_name is a string
             if not isinstance(display_name, str):
                 display_name = str(display_name) if display_name is not None else ""
+
+            # Enforce artifact-based success: the updater frequently exits without
+            # laying down the real payload (e.g. SetupUI.exe crashing). Do not
+            # report success unless the app binaries are actually present.
+            if not self.verify_affinity_artifacts(display_name):
+                self.update_progress_text("Update failed")
+                self.log(
+                    f"✗ {display_name} update did NOT complete: application files are missing.",
+                    "error",
+                )
+                self.refresh_status_signal.emit()
+                self.show_message(
+                    "Update Failed",
+                    f"{display_name} was NOT installed.\n\n"
+                    "The installer ran but no application files were written to the "
+                    "Wine prefix. Check ~/AffinitySetup.log for the full installer "
+                    "output and any crash details.",
+                    "error",
+                )
+                return
+
+            # Remove Wine desktop entries created by the installer
+            desktop_dir = Path.home() / ".local" / "share" / "applications"
+            wine_desktop_dir = desktop_dir / "wine" / "Programs"
 
             # Map display names to possible Wine desktop entry names
             wine_entry_names = []
@@ -14406,6 +14618,38 @@ Would you like to continue with {distro_name} anyway?"""
                     "info",
                 )
 
+            if self.check_cancelled():
+                self.log("Installation cancelled.", "warning")
+                return
+
+            # Enforce artifact-based success before running any post-install steps
+            # or creating desktop entries. The installer can exit without writing
+            # the real payload (e.g. SetupUI.exe crashing), which previously still
+            # reported success and produced a launcher pointing at a missing exe.
+            display_name = {
+                "Add": "Affinity (Unified)",
+                "Photo": "Affinity Photo",
+                "Designer": "Affinity Designer",
+                "Publisher": "Affinity Publisher",
+            }.get(app_name, app_name)
+            if not self.verify_affinity_artifacts(display_name):
+                self.update_progress_text("Installation failed")
+                self.log(
+                    f"✗ {display_name} installation did NOT complete: application files are missing.",
+                    "error",
+                )
+                self.refresh_status_signal.emit()
+                self.show_message(
+                    "Installation Failed",
+                    f"{display_name} was NOT installed.\n\n"
+                    "The installer ran but no application files were written to the "
+                    "Wine prefix. No desktop entry was created. Check "
+                    "~/AffinitySetup.log for the full installer output and any crash "
+                    "details.",
+                    "error",
+                )
+                return
+
             # Restore WinMetadata (only needed for Wine 9.14 and 10.10, not 11.12+)
             wine_version = self.get_current_wine_version()
             if wine_version in ["9.14", "10.10"]:
@@ -14487,12 +14731,6 @@ Would you like to continue with {distro_name} anyway?"""
 
             self.update_progress(1.0)
             self.update_progress_text("Installation complete!")
-            display_name = {
-                "Add": "Affinity (Unified)",
-                "Photo": "Affinity Photo",
-                "Designer": "Affinity Designer",
-                "Publisher": "Affinity Publisher",
-            }.get(app_name, app_name)
             self.log(f"\n✓ {display_name} installation completed!", "success")
             self.log("You can now launch it from your application menu.", "info")
 
@@ -16073,15 +16311,15 @@ Would you like to continue with {distro_name} anyway?"""
         if app_name == "Add":
             desktop_file = desktop_dir / "Affinity.desktop"
 
-        wine = self.get_wine_path("wine")
-        app_path = (
-            Path(self.directory)
-            / "drive_c"
-            / "Program Files"
-            / "Affinity"
-            / dir_name
-            / exe
+        wine = self.get_wine_tkg_for_installer("wine")
+        install_dir = (
+            Path(self.directory) / "drive_c" / "Program Files" / "Affinity" / dir_name
         )
+        if app_name == "Add":
+            hook_exe = install_dir / "AffinityHook.exe"
+            if hook_exe.exists():
+                exe = "AffinityHook.exe"
+        app_path = install_dir / exe
         icon_path = Path.home() / ".local" / "share" / "icons" / icon
 
         # Normalize all paths to strings to avoid double slashes
@@ -16116,7 +16354,7 @@ Would you like to continue with {distro_name} anyway?"""
                 exec_line += f" {gpu_env.strip()}"
             if dxvk_env:
                 exec_line += f" {dxvk_env.strip()}"
-            exec_line += f' {wine_str} "{app_path_str}"'
+            exec_line += f' {wine_str} start /unix "{app_path_str}"'
             f.write(f"{exec_line}\n")
             f.write("Terminal=false\n")
             f.write("Type=Application\n")
@@ -17880,19 +18118,19 @@ Would you like to continue with {distro_name} anyway?"""
             self.show_message(
                 "Affinity Not Found",
                 "Affinity v3 is not installed.\n\nPlease install it first using:\n'Update Affinity Applications' → 'Affinity (Unified)'",
-                QMessageBox.Icon.Warning,
+                "warning",
             )
             return
 
         # Check if Wine is set up
-        wine_bin = self.get_wine_path("wine")
+        wine_bin = Path(self.get_wine_tkg_for_installer("wine"))
         if not wine_bin.exists():
             self.log("✗ Wine is not set up", "error")
             self.log("Please run 'Setup Wine Environment' first", "info")
             self.show_message(
                 "Wine Not Found",
                 "Wine is not set up.\n\nPlease run 'Setup Wine Environment' first.",
-                QMessageBox.Icon.Warning,
+                "warning",
             )
             return
 
@@ -17901,13 +18139,10 @@ Would you like to continue with {distro_name} anyway?"""
         # Prepare environment variables
         env = os.environ.copy()
 
-        # Set PATH to include Wine binaries (only for custom Wine builds)
-        wine_dir = self.get_wine_dir()
-        if wine_dir:
-            wine_dir_str = str(wine_dir)
-            current_path = env.get("PATH", "")
-            env["PATH"] = f"{wine_dir_str}/bin:{current_path}"
-        # For system Wine, it's already in PATH
+        # Ensure selected Wine directory is first in PATH for wineserver/wineboot helpers
+        wine_parent = str(wine_bin.parent)
+        current_path = env.get("PATH", "")
+        env["PATH"] = f"{wine_parent}:{current_path}"
 
         # Set Wine-related environment variables
         env["WINE"] = str(wine_bin)
@@ -18041,7 +18276,7 @@ Would you like to continue with {distro_name} anyway?"""
             self.show_message(
                 "Launch Failed",
                 f"Failed to launch Affinity v3:\n\n{str(e)}",
-                QMessageBox.Icon.Critical,
+                "error",
             )
 
     def download_affinity_installer(self):
@@ -18107,7 +18342,7 @@ Would you like to continue with {distro_name} anyway?"""
             self.show_message(
                 "Affinity Not Found",
                 f"Affinity install directory not found:\n{install_dir}\n\nPlease install Affinity first.",
-                QMessageBox.Icon.Warning,
+                "warning",
             )
             return
 
@@ -18266,7 +18501,7 @@ Would you like to continue with {distro_name} anyway?"""
                 "Installation Complete",
                 f"AffinityPluginLoader ({tag}) and WineFix have been installed successfully.\n\n"
                 "Affinity.desktop has been updated to launch via AffinityHook.exe.",
-                QMessageBox.Icon.Information,
+                "info",
             )
 
         except Exception as e:
@@ -18386,7 +18621,7 @@ Would you like to continue with {distro_name} anyway?"""
         exe_name = "AffinityHook.exe" if (prefer_hook and hook_exe.exists()) else "Affinity.exe"
         app_path_str = str(install_dir / exe_name).replace("\\", "/")
 
-        wine_str = str(self.get_wine_path("wine"))
+        wine_str = str(self.get_wine_tkg_for_installer("wine"))
         directory_str = str(self.directory).rstrip("/")
 
         # get_gpu_env_vars()/get_dxvk_env_vars() already return a trailing space
@@ -18400,6 +18635,8 @@ Would you like to continue with {distro_name} anyway?"""
         if dxvk_env:
             segments.append(dxvk_env)
         segments.append(wine_str)
+        segments.append("start")
+        segments.append("/unix")
         segments.append(f'"{app_path_str}"')
 
         return "Exec=" + " ".join(segments), exe_name
@@ -18478,7 +18715,7 @@ Would you like to continue with {distro_name} anyway?"""
             self.show_message(
                 "Affinity Not Installed",
                 f"Could not find:\n{install_dir}\n\nPlease install Affinity first.",
-                QMessageBox.Icon.Warning,
+                "warning",
             )
             return
 

--- a/AffinityScripts/AffinityLinuxInstaller_INDEX.md
+++ b/AffinityScripts/AffinityLinuxInstaller_INDEX.md
@@ -1,0 +1,126 @@
+# AffinityLinuxInstaller.py AI Index
+
+Source: `AffinityScripts/AffinityLinuxInstaller.py` (lines `1-19007`)
+
+## Fast Navigation
+
+- **Entrypoint**: `main()` at `AffinityScripts/AffinityLinuxInstaller.py:18962`
+- **Main application class**: `AffinityInstallerGUI` at `AffinityScripts/AffinityLinuxInstaller.py:294`
+- **Huge method container**: `AffinityInstallerGUI` methods span `315-18927`
+
+## Top-Level Structure
+
+| Section | Line Range | Purpose |
+|---|---:|---|
+| Bootstrap + dependency install helpers | `27-79` | Detect distro and install missing Python packages |
+| PyQt6 import/bootstrap logic | `82-220` | Import PyQt6 and fallback install path |
+| UI helper widgets | `223-291` | `ZoomableTextEdit`, `ProgressSpinner` |
+| Main GUI class | `294-18927` | All installer logic, UI, workflows, system integration |
+| Cleanup helper | `18930-18959` | Kill stalled Wine processes |
+| Entrypoint | `18962-19007` | Start QApplication and GUI |
+
+## Main Class Section Map (`AffinityInstallerGUI`)
+
+### 1) App initialization and theming
+- `__init__`: `315-482`
+- Deferred startup + install status checks: `484-717`
+- Zoom and icon utilities: `719-834`
+- Theme switching and style sheets: `836-2394`
+
+### 2) UI construction
+- Build primary UI/layout sections: `2396-2965`
+- Reusable button groups and button wiring: `2967-3095`
+- Spinner and icon loading helpers: `3097-3211`
+- Window close and logging/spec utilities: `3213-3399`
+
+### 3) Operation lifecycle, dialogs, auth
+- Progress and cancellation lifecycle: `3401-3489`
+- Message dialogs and thread-safe UI updates: `3491-3515`
+- Sudo password + interactive prompts: `3517-3800`
+- Wine version dialog and question dialogs: `3802-4341`
+
+### 4) Wine runtime discovery and process execution
+- CPU generation and Wine path/version helpers: `4343-4698`
+- Wine-TKG acquisition/verification: `4718-5265`
+- Process registry/termination + command runners: `5339-6305`
+- Distro detection and icon prep: `6311-6478`
+
+### 5) GPU and graphics backend management
+- GPU detection and selection: `6480-7060`
+- DXVK/VKD3D env, switching, backend reconfiguration: `7079-7802`
+- Desktop entry updates after backend changes: `7804-7903`
+
+### 6) Initialization, dependency install, core setup
+- Init flow + persisted install location: `7984-8066`
+- One-click setup workflow: `8068-8422`
+- Install entrypoints and dependency installers (per distro): `8424-10363`
+- Wine setup + winmetadata setup/reinstall: `10365-10859`
+
+### 7) DXVK/VKD3D versioning and override setup
+- Fetch/store latest and installed versions: `10861-10994`
+- Install/remove DLLs and overrides: `10996-11443`
+- VKD3D + Wine config: `11445-11657`
+
+### 8) Wine switching and dependency tools
+- Environment prep and cached downloads: `11664-11969`
+- Wine version switch UI + thread workers: `11971-12314`
+- System/winetricks dependency install routines: `12316-12652`
+
+### 9) Affinity settings, WebView2, custom installs, update
+- Affinity settings install + registry checks: `12654-13168`
+- WebView2 detection/install: `13170-13452`
+- Additional settings flow + custom file install: `13454-14149`
+- Update workflow + installation workflow: `14151-14646`
+
+### 10) Runtime patching, OpenCL, .NET, desktop entries
+- wintypes/winmetadata handling: `14648-14871`
+- OpenCL and renderer config: `14873-15288`
+- .NET SDK checks/install: `15308-17157`
+- Patcher build/run and DLL patching: `15629-16183`
+- Desktop entry creation + optional plugin loader: `16185-18909`
+- Thank-you dialog: `18911-18927`
+
+## High-Value Functions (Quick Jump)
+
+- `run_command`: `AffinityScripts/AffinityLinuxInstaller.py:5387`
+- `run_command_streaming`: `AffinityScripts/AffinityLinuxInstaller.py:5655`
+- `run_command_interactive`: `AffinityScripts/AffinityLinuxInstaller.py:6134`
+- `ensure_wine_tkg`: `AffinityScripts/AffinityLinuxInstaller.py:4718`
+- `check_dependencies`: `AffinityScripts/AffinityLinuxInstaller.py:8863`
+- `setup_wine`: `AffinityScripts/AffinityLinuxInstaller.py:10365`
+- `switch_to_vkd3d`: `AffinityScripts/AffinityLinuxInstaller.py:7361`
+- `switch_to_dxvk`: `AffinityScripts/AffinityLinuxInstaller.py:7548`
+- `install_affinity_settings`: `AffinityScripts/AffinityLinuxInstaller.py:12654`
+- `run_installation`: `AffinityScripts/AffinityLinuxInstaller.py:14438`
+- `launch_affinity_v3`: `AffinityScripts/AffinityLinuxInstaller.py:17994`
+
+## AI Exploration Strategy (Context-Efficient)
+
+1. Start with this index and only open the line range you need.
+2. For workflow bugs, open the entrypoint method and immediately open called helpers.
+3. For backend issues, focus on `6480-7802` and skip UI style blocks.
+4. For install failures, focus on `8424-11657` and command runners `5387-6305`.
+5. For patcher/.NET issues, focus on `15308-17379`.
+
+## Suggested Chunking for LLM Reads
+
+- Chunk A: `1-834` (bootstrap + widgets + core init)
+- Chunk B: `836-2394` (themes/styles only)
+- Chunk C: `2396-3800` (UI build + dialogs + operation lifecycle)
+- Chunk D: `3802-6305` (dialogs, Wine runtime, command execution)
+- Chunk E: `6311-8422` (distro/gpu/init/one-click)
+- Chunk F: `8424-11657` (dependency + Wine setup + DXVK/VKD3D setup)
+- Chunk G: `11664-14646` (switching, settings, custom/update/install flows)
+- Chunk H: `14648-17379` (wintypes/opencl/.NET/patching)
+- Chunk I: `17381-19007` (dpi/uninstall/launch/plugin loader/entrypoint)
+
+## Generated Symbol Summary
+
+Top-level symbols:
+- `detect_distro_for_install`: `27-40`
+- `install_package`: `43-79`
+- `ZoomableTextEdit`: `223-249`
+- `ProgressSpinner`: `252-291`
+- `AffinityInstallerGUI`: `294-18927`
+- `kill_stalled_wine_processes`: `18930-18959`
+- `main`: `18962-19007`

--- a/_pr_notes_temp/ZORIN_AFFINITY_WINE_TROUBLESHOOTING_NOTES.md
+++ b/_pr_notes_temp/ZORIN_AFFINITY_WINE_TROUBLESHOOTING_NOTES.md
@@ -1,0 +1,659 @@
+# AI Notes: Debugging Affinity on Wine
+
+## Purpose
+
+This document is a technical handoff for AI agents and maintainers diagnosing Affinity installation and startup failures under Wine. It records the reasoning model, important Wine semantics, failure signatures, safe investigation order, and lessons learned from the Zorin OS 18.1 incident.
+
+The central lesson is that "Affinity does not start" is not one problem. It may mean:
+
+- the application was never installed;
+- the launcher selects the wrong Wine runtime;
+- Wine invocation hangs even though another invocation works;
+- a native DLL override points to a file that is absent or is actually a builtin module;
+- a low-level graphics DLL failure produces dozens of misleading higher-level missing-library errors;
+- the process starts but exits after initialization;
+- the process remains alive but no window is visible;
+- the installer reports success based on process behavior rather than installed artifacts.
+
+Do not reinstall until these states have been distinguished.
+
+## Repository and runtime model
+
+### Main artifact
+
+The active installer is:
+
+```text
+AffinityScripts/AffinityLinuxInstaller.py
+```
+
+It is a large PyQt6 application. Long operations run in worker threads and must communicate with Qt widgets through signals. The prefix and runtime are managed by the installer rather than by system Wine alone.
+
+### Important paths
+
+```text
+Installer root:       ~/.AffinityLinux
+Wine prefix:          ~/.AffinityLinux
+Current wine-tkg:     ~/.AffinityLinux/wine-tkg/<version>/bin/wine
+Legacy bundled Wine:  ~/.AffinityLinux/ElementalWarriorWine/bin/wine
+Unified Affinity:     ~/.AffinityLinux/drive_c/Program Files/Affinity/Affinity/Affinity.exe
+Plugin loader target: ~/.AffinityLinux/drive_c/Program Files/Affinity/Affinity/AffinityHook.exe
+Desktop entry:        ~/.local/share/applications/Affinity.desktop
+Installer log:        ~/AffinitySetup.log
+Wine debug log:       ~/wine-tkg-debug.log
+```
+
+The prefix path is `~/.AffinityLinux`, not `~/.AffinityLinux/Prefix`.
+
+## Mental model: diagnose in layers
+
+Always debug from the lowest unambiguous layer upward.
+
+### Layer 1: installation artifacts
+
+First determine whether the application exists:
+
+```bash
+ls -la "$HOME/.AffinityLinux/drive_c/Program Files/Affinity/Affinity"
+```
+
+For unified Affinity, require at least one of:
+
+```text
+Affinity.exe
+Serif.Affinity.dll
+```
+
+If neither exists, this is an installation failure. Launcher changes cannot fix it. Investigate the installer process and do not report installation success.
+
+If the app directory is populated, do not reinstall immediately. Continue to launcher and runtime checks.
+
+### Layer 2: Wine binary selection
+
+Multiple Wine installations can coexist:
+
+```text
+system Wine
+ElementalWarrior Wine
+wine-tkg
+```
+
+A Wine binary merely existing does not mean it is the runtime used by all subprocesses. Check:
+
+- the full executable path;
+- `wine --version` for each candidate;
+- whether the binary passes a functional smoke test;
+- whether its directory is first in `PATH` for `wineserver`, `wineboot`, and helper programs;
+- whether installer, winetricks, launcher, and desktop regeneration all use the same selector.
+
+The correct shared selector in this installer is generally:
+
+```python
+get_wine_tkg_for_installer("wine")
+```
+
+The legacy selector:
+
+```python
+get_wine_path("wine")
+```
+
+may resolve to the older ElementalWarrior tree and should not be used when writing current Affinity launchers.
+
+### Layer 3: command form
+
+The command form matters independently of the Wine binary.
+
+On the diagnosed Zorin system:
+
+```text
+wine ".../Affinity.exe"              -> hangs; killed later; rc=137
+wine start /unix ".../Affinity.exe"  -> starts asynchronously; launcher rc=0
+```
+
+`rc=137` means the process received `SIGKILL` (`128 + 9`). It does not mean Wine naturally returned an Affinity error code. Usually a timeout or manual kill terminated a hung process.
+
+`wine start /unix` returning zero only proves Wine accepted the launch request. It does not prove Affinity remained alive. Always check the process after a delay.
+
+Recommended launcher form:
+
+```bash
+env WINEPREFIX="$HOME/.AffinityLinux" \
+  "$HOME/.AffinityLinux/wine-tkg/<version>/bin/wine" \
+  start /unix "$HOME/.AffinityLinux/drive_c/Program Files/Affinity/Affinity/Affinity.exe"
+```
+
+If `AffinityHook.exe` exists and plugin-loader behavior is desired, target it instead.
+
+### Layer 4: desktop-entry regeneration
+
+A manually repaired desktop file can be broken again by:
+
+- application installation;
+- application update;
+- GPU configuration changes;
+- DXVK/vkd3d backend switching;
+- plugin-loader installation;
+- generic desktop-entry update functions.
+
+Search every code path that writes or patches `Exec=`. Fixing only `create_desktop_entry()` is incomplete if backend switching later reconstructs a legacy command.
+
+Required invariants:
+
+```text
+selected Wine = get_wine_tkg_for_installer("wine")
+command form  = wine start /unix "<full Linux path>"
+unified target = AffinityHook.exe if present, otherwise Affinity.exe
+```
+
+When parsing existing desktop entries, recognize both forms:
+
+```text
+wine "...exe"
+wine start /unix "...exe"
+```
+
+Never split executable paths on whitespace. `Program Files` makes that approach corrupt the path.
+
+### Layer 5: DLL loading and graphics stack
+
+If the executable exists and the launch command is correct, capture Wine loader errors. The earliest dependency failure is usually more important than the last error line.
+
+Use a bounded command so a hang does not block debugging indefinitely:
+
+```bash
+timeout 45 env \
+  WINEPREFIX="$HOME/.AffinityLinux" \
+  WINEDEBUG=+loaddll,+err \
+  "$HOME/.AffinityLinux/wine-tkg/<version>/bin/wine" \
+  "C:/Program Files/Affinity/Affinity/Affinity.exe" \
+  > /tmp/affinity.out 2> /tmp/affinity.err
+```
+
+Then inspect:
+
+```bash
+grep -E ':err:|not found|failed|exception' /tmp/affinity.err
+tail -50 /tmp/affinity.err
+```
+
+Do not assume every "not found" message means the named Affinity DLL is absent on disk. Wine's loader reports a dependent module as unavailable when any of its imports cannot be resolved.
+
+## The vkd3d-proton failure in depth
+
+### Observed cascade
+
+The first meaningful failure was:
+
+```text
+Library d3d12.dll (which is needed by libdxcore.dll) not found
+```
+
+That caused subsequent failures:
+
+```text
+libdxcore.dll not found
+libraster.dll not found
+librenderer.dll not found
+libStory.dll not found
+libpsd.dll not found
+libpersona.dll not found
+```
+
+Most of those files existed. They were reported unavailable because their dependency chain included `d3d12.dll` through `libdxcore.dll`.
+
+The correct reasoning is:
+
+```text
+d3d12 fails
+  -> libdxcore cannot load
+  -> libraster cannot load
+  -> rendering/story/PSD libraries cannot load
+  -> libpersona cannot load
+  -> Affinity startup cannot complete
+```
+
+Fix the first dependency failure, not every downstream error.
+
+### Why an existing d3d12.dll was still "not found"
+
+The prefix contained:
+
+```text
+drive_c/windows/system32/d3d12.dll
+drive_c/windows/system32/d3d12core.dll
+```
+
+Architecture checks showed they were 64-bit, which initially looked correct. However, string/import inspection showed the installed `d3d12.dll` imported `wined3d.dll`; it was Wine's builtin PE module, not the downloaded vkd3d-proton native DLL.
+
+The registry contained:
+
+```text
+"d3d12"="native"
+"d3d12core"="native"
+```
+
+Wine DLL override semantics matter:
+
+- `builtin`: load Wine's implementation;
+- `native`: load a Windows/native DLL from the prefix;
+- `native,builtin`: prefer native, then fall back to builtin;
+- `builtin,native`: prefer builtin, then native.
+
+A builtin module stored in `system32` does not satisfy a native-only request merely because the filename exists. Wine rejects it for the requested load order and reports the library as unavailable.
+
+### Where the real DLLs were
+
+The real vkd3d-proton files had been downloaded and extracted under:
+
+```text
+~/.AffinityLinux/dxvk/vkd3d-proton-<version>/x64/
+~/.AffinityLinux/dxvk/vkd3d-proton-<version>/x86/
+```
+
+The installer also staged only 64-bit copies under:
+
+```text
+~/.AffinityLinux/vkd3d_dlls/
+<Wine tree>/lib/wine/vkd3d-proton/x86_64-windows/
+```
+
+Staging them outside the prefix was insufficient for Wine's native DLL lookup in this configuration.
+
+### Correct installation
+
+Copy architecture-matched files:
+
+```text
+x64/d3d12.dll       -> drive_c/windows/system32/d3d12.dll
+x64/d3d12core.dll   -> drive_c/windows/system32/d3d12core.dll
+x86/d3d12.dll       -> drive_c/windows/syswow64/d3d12.dll
+x86/d3d12core.dll   -> drive_c/windows/syswow64/d3d12core.dll
+```
+
+Remember Wine's directory convention:
+
+- `system32` contains 64-bit DLLs in a 64-bit prefix;
+- `syswow64` contains 32-bit DLLs.
+
+This naming is historically counterintuitive. Do not swap architectures based on directory names.
+
+Back up existing files before replacement. Configure:
+
+```text
+"d3d12"="native,builtin"
+"d3d12core"="native,builtin"
+```
+
+After repair, verify source and destination architecture and size, then launch again with bounded logging.
+
+### Why reinstalling Affinity would not fix this
+
+Affinity's installer owns the app payload. The broken files and overrides were in the Wine prefix graphics runtime. Reinstalling the application could leave the same d3d12 configuration untouched and reproduce the hang.
+
+Reinstall only when:
+
+- app payload files are missing;
+- app payload checksums or file sizes indicate corruption;
+- installer/update interrupted replacement of Affinity files;
+- runtime and launcher layers have already been validated.
+
+## Installer false-positive success
+
+### Failure pattern
+
+The installer process started, exited quickly, and the script proceeded as though the update completed. Immediately afterward:
+
+```text
+Serif.Affinity.dll not found
+Affinity (Unified): Not installed
+```
+
+This is a process-success versus outcome-success bug.
+
+### Required success rule
+
+After every Affinity install/update attempt:
+
+1. capture the return code;
+2. record elapsed time;
+3. preserve relevant stdout/stderr;
+4. wait for related Wine processes only when appropriate;
+5. verify actual installation artifacts;
+6. report success only if artifacts exist;
+7. do not create a launcher pointing at a missing executable.
+
+For unified Affinity, verify:
+
+```text
+Affinity.exe OR Serif.Affinity.dll
+```
+
+For v2 apps, verify the app-specific executable:
+
+```text
+Photo 2/Photo.exe
+Designer 2/Designer.exe
+Publisher 2/Publisher.exe
+```
+
+A debugger appearing, a launcher returning zero, or `wineserver -w` completing are not substitutes for artifact verification.
+
+## .NET/WPF installer exception
+
+The original Affinity `SetupUI.exe` crashed under Zorin's system Wine with:
+
+```text
+0xe0434352
+```
+
+This is a generic CLR exception code. It identifies a managed exception, not its exact cause. The stack referenced WPF/CLR components such as PresentationFramework, WindowsBase, and mscorlib.
+
+Correct response:
+
+- preserve the complete installer output;
+- note the exact Wine build used;
+- compare behavior under the selected wine-tkg build;
+- verify installed .NET and fonts;
+- do not interpret the generic exception code as proof of one specific missing DLL;
+- do not report success without artifacts.
+
+Changing the installer path to wine-tkg was necessary for consistency, but runtime validation remained necessary because the eventual launch blocker was separate.
+
+## WebView2 lessons
+
+### Detection layout
+
+WebView2 commonly installs the executable under a version directory:
+
+```text
+Program Files (x86)/Microsoft/EdgeWebView/Application/<version>/msedgewebview2.exe
+```
+
+Checking only:
+
+```text
+Application/msedgewebview2.exe
+```
+
+produces a false negative.
+
+Search both standard roots:
+
+```text
+Program Files (x86)/Microsoft/EdgeWebView/Application
+Program Files/Microsoft/EdgeWebView/Application
+```
+
+Check a direct executable and versioned child directories.
+
+### MSASN1 failure
+
+One installation attempt failed at:
+
+```text
+MSASN1.dll.ASN1DEREncBeginBlk
+```
+
+This indicates an unimplemented or unresolved Wine API path during that attempt. It should be recorded separately from Affinity's d3d12 launch failure. Do not collapse all errors into one root cause merely because they occur in the same prefix.
+
+## Qt threading and messages
+
+The GUI declares message signals using strings. Passing `QMessageBox.Icon.Warning` or similar enum values through a signal declared as `pyqtSignal(str, str, str)` raises a runtime type error and suppresses the user-facing dialog.
+
+Use the established string values:
+
+```text
+warning
+error
+info
+```
+
+Worker threads must not manipulate widgets directly. Emit signals to the corresponding safe main-thread slots.
+
+## GPU/backend rewrite risks
+
+DXVK and vkd3d-proton are distinct components:
+
+- DXVK primarily translates D3D8/9/10/11 to Vulkan;
+- vkd3d-proton translates D3D12 to Vulkan.
+
+Affinity v3's dependency chain includes D3D12 through `libdxcore.dll`, even when other parts of the app emit wined3d or D3D11 messages. Seeing wined3d/D3D11 logs does not prove D3D12 is irrelevant.
+
+Backend-switch functions often:
+
+- copy or remove DLLs;
+- change registry overrides;
+- rebuild desktop entries;
+- alter GPU environment variables.
+
+Therefore, every backend switch must preserve:
+
+- correct d3d12 DLL placement;
+- architecture matching;
+- safe overrides;
+- selected Wine path;
+- `start /unix` invocation;
+- plugin-loader target selection.
+
+## Reliable diagnostic procedure
+
+### Phase A: establish state
+
+1. Read `~/AffinitySetup.log` and `~/wine-tkg-debug.log`.
+2. Confirm distro, GPU, Wine versions, and prefix path.
+3. Check whether Affinity artifacts exist.
+4. Inspect the exact desktop `Exec=` line.
+5. Check whether `AffinityHook.exe` exists.
+
+### Phase B: isolate launcher behavior
+
+1. Run the exact desktop command.
+2. Record immediate return code.
+3. Check the process after 5, 15, and 30 seconds.
+4. Compare direct Wine invocation and `wine start /unix` only when needed.
+5. Avoid assuming asynchronous launcher success means app success.
+
+### Phase C: isolate loader failure
+
+1. Stop stale Wine processes with the selected Wine tree's `wineserver`.
+2. Run with a timeout and targeted `WINEDEBUG` channels.
+3. Save stdout and stderr to files.
+4. Find the earliest meaningful `import_dll` or exception error.
+5. Build the dependency chain from that error.
+6. Inspect actual DLL architecture and imports.
+7. Inspect `DllOverrides` in the registry or `user.reg`.
+
+### Phase D: repair safely
+
+1. Back up files being replaced.
+2. Use cached, already downloaded vkd3d-proton files when available.
+3. Copy x64 to `system32` and x86 to `syswow64`.
+4. Use `native,builtin` unless there is a documented reason for native-only.
+5. Restart the Wine server.
+6. Re-run the exact desktop command.
+7. Confirm the process remains alive.
+8. Confirm the original first loader error is absent.
+
+### Phase E: make the fix persistent
+
+1. Find all installer functions that stage, copy, or remove the affected DLLs.
+2. Find all functions that set or remove DLL overrides.
+3. Find all desktop-entry generation and rewrite paths.
+4. Use one Wine selector consistently.
+5. Add artifact-based install validation.
+6. Syntax-check the Python script.
+7. Test an installer-created launcher, not only a manually edited one.
+
+## Commands and interpretation
+
+### Confirm artifact presence
+
+```bash
+ls -la "$HOME/.AffinityLinux/drive_c/Program Files/Affinity/Affinity"
+```
+
+Empty or missing directory: installation problem.
+
+### Inspect launcher
+
+```bash
+grep '^Exec=' "$HOME/.local/share/applications/Affinity.desktop"
+```
+
+Check Wine path, `WINEPREFIX`, `start /unix`, quoting, and target executable.
+
+### Inspect DLL architecture
+
+```bash
+file "$HOME/.AffinityLinux/drive_c/windows/system32/d3d12.dll"
+file "$HOME/.AffinityLinux/drive_c/windows/syswow64/d3d12.dll"
+```
+
+Expected:
+
+```text
+system32: PE32+ x86-64
+syswow64: PE32 Intel 80386
+```
+
+### Distinguish builtin-like and vkd3d-proton DLLs
+
+```bash
+strings "$HOME/.AffinityLinux/drive_c/windows/system32/d3d12.dll" \
+  | grep -iE 'wined3d|d3d12core|vulkan'
+```
+
+This is a heuristic, not a formal signature check. Compare against the known extracted vkd3d-proton source and file size.
+
+### Inspect overrides
+
+```bash
+awk '/\[Software\\\\Wine\\\\DllOverrides\]/,/^$/' \
+  "$HOME/.AffinityLinux/user.reg"
+```
+
+Registry commands are preferable for changing values while Wine is not actively mutating the prefix.
+
+### Check process persistence
+
+```bash
+pgrep -af 'Affinity.exe|AffinityHook.exe'
+```
+
+Check after multiple delays. A process that appears briefly and exits is a different failure from a launch request that never creates it.
+
+## Common reasoning mistakes
+
+### Mistake: recommend reinstalling immediately
+
+Why wrong: application reinstall does not repair the Wine runtime, DLL overrides, desktop regeneration code, or mismatched Wine selection.
+
+### Mistake: trust the installer success message
+
+Why wrong: the original flow reported success with an empty app directory.
+
+### Mistake: trust `rc=0` from `wine start`
+
+Why wrong: `start` is asynchronous. It confirms request acceptance, not a healthy persistent app.
+
+### Mistake: treat `rc=137` as an Affinity exit code
+
+Why wrong: it usually indicates forced termination after a hang.
+
+### Mistake: fix every missing Affinity DLL
+
+Why wrong: one low-level dependency failure can make many present DLLs appear unloadable.
+
+### Mistake: assume a filename proves the correct DLL implementation
+
+Why wrong: a Wine builtin PE module and a native vkd3d-proton DLL can share the same filename and architecture.
+
+### Mistake: copy x86 to `system32`
+
+Why wrong: in a 64-bit Wine prefix, `system32` is 64-bit and `syswow64` is 32-bit.
+
+### Mistake: fix one desktop writer
+
+Why wrong: backend switching or plugin-loader installation can rewrite the entry later.
+
+### Mistake: mix Wine builds within one operation
+
+Why wrong: invoking one `wine` while helpers resolve from another Wine tree can produce inconsistent server and prefix behavior.
+
+## Current known-good state from the Zorin case
+
+The successful state included:
+
+```text
+Wine: wine-tkg 11.16 staging wow64
+Launcher: wine start /unix <full Linux path>
+d3d12 x64: vkd3d-proton files in system32
+d3d12 x86: vkd3d-proton files in syswow64
+Overrides: native,builtin
+Unified target: Affinity.exe (AffinityHook.exe absent)
+```
+
+Validation showed:
+
+- launcher return code `0`;
+- no `d3d12.dll ... not found` error;
+- `Affinity.exe` running after 5, 15, and 30 seconds;
+- installer Python syntax check passing.
+
+## Code areas to inspect first in future sessions
+
+Use symbol search because the main file is large:
+
+```text
+verify_affinity_artifacts
+_run_installer_and_capture
+update_existing_desktop_entries
+install_d3d12_dlls
+_find_vkd3d_dll_sources
+install_vkd3d_dlls_to_prefix
+setup_d3d12_overrides
+remove_d3d12_overrides
+_find_webview2_executable
+create_desktop_entry
+launch_affinity_v3
+_build_affinity_exec_line
+_patch_affinity_desktop_for_hook
+```
+
+Also inspect every occurrence of:
+
+```text
+Exec=env WINEPREFIX
+get_wine_path("wine")
+get_wine_tkg_for_installer("wine")
+d3d12core
+DllOverrides
+```
+
+## Completion criteria for an AI agent
+
+Do not declare this class of task complete until all applicable conditions hold:
+
+1. The requested app artifacts exist.
+2. The installer does not claim success without them.
+3. The desktop entry selects the intended Wine runtime.
+4. The launch command uses the validated command form.
+5. Plugin-loader behavior is preserved.
+6. Relevant native DLLs are in the prefix, not merely staged elsewhere.
+7. DLL architecture matches the target directory.
+8. Overrides have a safe and intentional load order.
+9. The original first loader error is gone.
+10. The app process remains alive after a meaningful delay.
+11. Installer regeneration does not undo the repair.
+12. `python3 -m py_compile AffinityScripts/AffinityLinuxInstaller.py` passes.
+
+## Source material
+
+These notes consolidate the repository logs and live debugging from 2026-08-24:
+
+- `logs/INSTALL_DEBUG_SUMMARY.md`
+- `logs/AFFINITY_V3_INSTALL_DEBUG_2026-08-24.md`
+- `logs/AFFINITY_V3_STATUS_2026-08-24.md`
+- `logs/ZORIN_OS_INSTALLER_ISSUE_PROMPT_2026-08-24.md`
+- `docs/ZORIN_OS_COMPATIBILITY.md`

--- a/_pr_notes_temp/ZORIN_OS_COMPATIBILITY.md
+++ b/_pr_notes_temp/ZORIN_OS_COMPATIBILITY.md
@@ -1,0 +1,269 @@
+# Zorin OS Compatibility: Affinity Installer and Runtime
+
+## Purpose
+
+This document consolidates the installation and launch issues reproduced on Zorin OS 18.1 while installing Affinity v3 with the Affinity Linux Installer. It is intended to support a pull request, future regression testing, and end-user troubleshooting.
+
+## Tested environment
+
+| Component | Observed value |
+|---|---|
+| Distribution | Zorin OS 18.1 |
+| GPU | Intel Raptor Lake-P Iris Xe |
+| RAM | 15.2 GB |
+| Wine prefix | `~/.AffinityLinux` |
+| System Wine | Wine 10.0 (`Ubuntu 10.0~repack-6ubuntu1+zorin5`) |
+| Legacy bundled Wine | ElementalWarrior Wine 11.12 |
+| Active installer/runtime Wine | wine-tkg 11.16 staging, wow64 |
+| Graphics path | Vulkan; OpenCL disabled for Intel |
+| Affinity application | Unified Affinity v3 |
+
+## Executive summary
+
+The failure was not caused by one isolated incompatibility. Several independent installer and runtime defects occurred in sequence:
+
+1. The Affinity installer was initially run with system Wine and its .NET/WPF `SetupUI.exe` crashed with exception `0xe0434352`.
+2. The installer flow reported success without verifying that Affinity binaries were actually installed.
+3. WebView2 detection did not recognize versioned installation directories.
+4. GUI error dialogs passed `QMessageBox.Icon` values through a signal declared to accept strings.
+5. Update buttons were disabled when an application was not already installed.
+6. Generated desktop entries selected the legacy Wine build and launched the executable directly instead of using the active wine-tkg build with `start /unix`.
+7. Most importantly, vkd3d-proton was downloaded and staged but its native `d3d12.dll` and `d3d12core.dll` files were not copied into the Wine prefix. Registry overrides forced those DLLs to `native`, causing Wine to reject its builtin DLL and report `d3d12.dll` as missing. This cascaded through Affinity's rendering libraries and caused the application to hang.
+
+Reinstalling Affinity alone would not reliably solve these problems. The Wine prefix configuration and installer logic had to be repaired.
+
+## Issue matrix
+
+| Area | Symptom | Root cause | Resolution |
+|---|---|---|---|
+| Affinity installer | `SetupUI.exe` crashed with `0xe0434352` | Affinity installer used Zorin's system Wine instead of the selected wine-tkg runtime | Use `get_wine_tkg_for_installer()` for Affinity and WebView2 installer execution |
+| Success reporting | Installer displayed completion while app directory was empty | Process completion was treated as installation success | Verify `Affinity.exe` or `Serif.Affinity.dll` before reporting success or creating launchers |
+| Diagnostics | Failures were difficult to distinguish from successful short runs | Exit code, elapsed time, and complete installer output were not retained | Capture streaming return code and installer output |
+| GUI messages | Error dialogs raised a signal type exception | Signal expected strings but call sites passed `QMessageBox.Icon` values | Pass `"warning"`, `"error"`, or `"info"` |
+| Update controls | Uninstalled apps could not be selected for update/install | Buttons required both Wine and an existing installation | Enable controls when a usable Wine runtime exists |
+| WebView2 | Installed runtime was reported missing | Detection only checked `Application/msedgewebview2.exe` | Search versioned `Application/<version>/msedgewebview2.exe` directories |
+| Desktop entries | Menu launch used obsolete Wine and hung | Desktop writers called `get_wine_path("wine")` and invoked the EXE directly | Use active wine-tkg selection and `wine start /unix` |
+| Plugin loader | Launcher rewrites could bypass `AffinityHook.exe` | Separate desktop rewrite paths reconstructed inconsistent commands | Prefer `AffinityHook.exe` when present, otherwise `Affinity.exe` |
+| Graphics runtime | `Affinity.exe` hung and was eventually killed with `rc=137` | Native d3d12 overrides existed, but vkd3d-proton DLLs were absent from the prefix system directories | Install x64 DLLs into `system32`, x86 DLLs into `syswow64`, and use `native,builtin` fallback |
+| Wine selection | Setup logs referenced Wine 11.12 while parts of setup used wine-tkg 11.16 | Multiple Wine selectors were used for related operations | Use the selected Wine consistently for installation and launch paths |
+
+## Failure chronology
+
+### 1. Initial environment setup
+
+System dependencies, wine-tkg 11.16, .NET, fonts, Visual C++ runtime, XML components, and Vulkan configuration were installed. The setup logs also exposed a Wine-version inconsistency: the UI reported ElementalWarrior Wine 11.12 as active while winetricks and later operations used wine-tkg 11.16.
+
+A cache entry for Wine 11.12-v4 was also reported as successful despite the expected cache directory being absent. This was not the final launch blocker, but it made Wine selection harder to reason about.
+
+### 2. Affinity installer crash and false success
+
+The original app installation path selected system Wine. Affinity's `SetupUI.exe` failed with an unhandled CLR/WPF exception:
+
+```text
+wine: Unhandled exception 0xe0434352 ...
+```
+
+No app payload was written to:
+
+```text
+~/.AffinityLinux/drive_c/Program Files/Affinity/Affinity
+```
+
+Nevertheless, the installer continued into post-install actions and reported success. `Serif.Affinity.dll` was missing, patching was skipped, and the final status still showed Affinity as not installed.
+
+The installer must treat the presence of real artifacts as the success condition. A zero exit code, a debugger process, or a short-lived installer process is not sufficient evidence that installation completed.
+
+### 3. WebView2 and UI secondary failures
+
+The first WebView2 attempt encountered:
+
+```text
+MSASN1.dll.ASN1DEREncBeginBlk
+```
+
+A later attempt found WebView2 through registry state, but file detection still missed valid versioned installations. Detection now searches both 32-bit and 64-bit standard roots and their versioned subdirectories.
+
+At the same time, attempts to display failure dialogs raised:
+
+```text
+show_message_signal[str, str, str].emit(): argument 3 has unexpected type 'Icon'
+```
+
+This hid useful error messages from the user and was corrected by passing string severity values.
+
+### 4. Desktop launcher regeneration failure
+
+After Affinity was installed, installer actions could regenerate `Affinity.desktop` with two regressions:
+
+- the legacy ElementalWarrior Wine path;
+- direct executable invocation.
+
+On this system, direct invocation behaved as follows:
+
+```text
+wine ".../Affinity.exe"                 -> hangs, later killed, rc=137
+wine start /unix ".../Affinity.exe"     -> returns rc=0
+```
+
+The launcher must use the same selected Wine runtime as the installer:
+
+```text
+Exec=env WINEPREFIX=<prefix> <selected-wine> start /unix "<linux-exe-path>"
+```
+
+All desktop creation and GPU/backend rewrite paths must preserve this format. The unified launcher must target `AffinityHook.exe` when the plugin loader is installed and fall back to `Affinity.exe` otherwise.
+
+### 5. Final runtime blocker: broken vkd3d-proton installation
+
+Correcting the launcher exposed a deeper graphics failure. Wine debug output repeatedly reported:
+
+```text
+Library d3d12.dll (which is needed by libdxcore.dll) not found
+```
+
+The error then cascaded through:
+
+```text
+libdxcore.dll
+  -> libraster.dll
+  -> librenderer.dll / libStory.dll / libpsd.dll
+  -> libpersona.dll
+  -> Affinity startup failure
+```
+
+The prefix contained files named `d3d12.dll` and `d3d12core.dll`, but they were Wine builtin modules. The registry forced:
+
+```text
+"d3d12"="native"
+"d3d12core"="native"
+```
+
+Wine will not satisfy a native-only override with its builtin module. The actual vkd3d-proton DLLs existed under the installer cache but had only been copied to a staging directory and a Wine installation library directory. They were never installed into the prefix locations used by native DLL lookup.
+
+The working installation is:
+
+| Architecture | vkd3d-proton source | Prefix destination |
+|---|---|---|
+| 64-bit | `vkd3d-proton-<version>/x64/*.dll` | `drive_c/windows/system32/` |
+| 32-bit | `vkd3d-proton-<version>/x86/*.dll` | `drive_c/windows/syswow64/` |
+
+The safer overrides are:
+
+```text
+"d3d12"="native,builtin"
+"d3d12core"="native,builtin"
+```
+
+This loads vkd3d-proton when correctly installed while avoiding a complete dependency failure if a native DLL is unavailable.
+
+## Implemented code behavior
+
+The installer now includes or is expected to include the following behavior:
+
+- Select wine-tkg through `get_wine_tkg_for_installer()` for Affinity and WebView2 installers.
+- Put the selected Wine binary directory first in `PATH` so helper processes use the same runtime.
+- Record streaming command return codes, elapsed runtime, and detailed Affinity installer output.
+- Verify installed artifacts before reporting success.
+- Detect WebView2 executables inside versioned installation directories.
+- Generate and rebuild desktop entries with the selected Wine runtime and `start /unix`.
+- Preserve `AffinityHook.exe` preference for the plugin-loader path.
+- Locate cached x64 and x86 vkd3d-proton DLLs.
+- Back up existing prefix d3d12 files before replacement.
+- Copy x64 DLLs into `system32` and x86 DLLs into `syswow64`.
+- Configure d3d12 overrides as `native,builtin`.
+
+Primary implementation areas in `AffinityScripts/AffinityLinuxInstaller.py` include:
+
+- `verify_affinity_artifacts`
+- `_run_installer_and_capture`
+- `update_existing_desktop_entries`
+- `install_d3d12_dlls`
+- `_find_vkd3d_dll_sources`
+- `install_vkd3d_dlls_to_prefix`
+- `setup_d3d12_overrides`
+- `_find_webview2_executable`
+- `create_desktop_entry`
+- `launch_affinity_v3`
+- `_build_affinity_exec_line`
+
+## Validation results
+
+The repaired prefix was validated with the following outcomes:
+
+- Python syntax validation passed:
+
+```bash
+python3 -m py_compile AffinityScripts/AffinityLinuxInstaller.py
+```
+
+- The desktop entry uses wine-tkg and `start /unix`:
+
+```text
+Exec=env WINEPREFIX=/home/blade/.AffinityLinux /home/blade/.AffinityLinux/wine-tkg/wine-11.16-staging-tkg-amd64-wow64/bin/wine start /unix "/home/blade/.AffinityLinux/drive_c/Program Files/Affinity/Affinity/Affinity.exe"
+```
+
+- The x64 vkd3d-proton DLL sizes in `system32` matched the cached x64 sources.
+- The x86 vkd3d-proton DLL sizes in `syswow64` matched the cached x86 sources.
+- `d3d12` and `d3d12core` registry values were verified as `native,builtin`.
+- The exact desktop command returned `rc=0`.
+- `Affinity.exe` remained running after 5, 15, and 30 seconds.
+- The prior `Library d3d12.dll ... not found` error disappeared.
+
+## Pull request scope and rationale
+
+### Problem solved
+
+Zorin OS users could complete setup yet receive a missing application, a broken launcher, or an Affinity process that hung during startup. Reinstalling could reproduce the same state because the root defects were in Wine selection, success validation, launcher regeneration, and vkd3d-proton placement.
+
+### User impact
+
+- Failed installs are no longer reported as successful.
+- Error dialogs display correctly.
+- Existing WebView2 installations are recognized.
+- Launchers consistently use the tested Wine runtime and reliable invocation form.
+- Affinity's D3D12 dependency chain can load correctly from the prefix.
+- Plugin-loader launch behavior is preserved.
+
+### Suggested PR summary
+
+- Make Affinity installation and launcher generation consistently use the selected wine-tkg runtime, and reject false-positive installations when required app files are absent.
+- Install vkd3d-proton DLLs into the Wine prefix with safe overrides so Affinity's D3D12 rendering dependencies load reliably on Zorin OS.
+
+## Regression checklist
+
+Before merging, test on at least one supported distribution and verify:
+
+1. A fresh unified Affinity install creates `Affinity.exe` or `Serif.Affinity.dll` before reporting success.
+2. A deliberately failed installer does not create a desktop entry or show a success dialog.
+3. `Affinity.desktop` uses the selected wine-tkg path and `start /unix`.
+4. `AffinityHook.exe` is selected when installed.
+5. Photo, Designer, and Publisher desktop entries still point to their correct executable paths.
+6. GPU/backend switching does not rewrite launchers back to legacy Wine or direct invocation.
+7. `system32/d3d12.dll` and `system32/d3d12core.dll` are the x64 vkd3d-proton files.
+8. `syswow64/d3d12.dll` and `syswow64/d3d12core.dll` are the x86 vkd3d-proton files.
+9. Registry overrides are `native,builtin`.
+10. Affinity remains running for at least 30 seconds after launch.
+11. WebView2 is detected in a versioned directory.
+12. `python3 -m py_compile AffinityScripts/AffinityLinuxInstaller.py` passes.
+
+## End-user recovery guidance
+
+Do not recommend reinstalling Affinity as the first action when the executable exists. First determine whether the failure is installation, launcher selection, or graphics runtime configuration:
+
+1. Confirm `Affinity.exe` exists.
+2. Inspect the desktop `Exec=` line.
+3. Confirm the selected Wine binary runs.
+4. Capture Wine errors and look specifically for the first missing dependency.
+5. Verify vkd3d-proton DLL architecture and placement.
+6. Verify DLL overrides.
+7. Reinstall only if the Affinity payload itself is missing or corrupt after the installer path has been corrected.
+
+## Source diagnostic documents
+
+This compatibility report consolidates:
+
+- `logs/INSTALL_DEBUG_SUMMARY.md`
+- `logs/AFFINITY_V3_INSTALL_DEBUG_2026-08-24.md`
+- `logs/AFFINITY_V3_STATUS_2026-08-24.md`
+- `logs/ZORIN_OS_INSTALLER_ISSUE_PROMPT_2026-08-24.md`
+- Runtime diagnostics performed on 2026-08-24 after the launcher fix


### PR DESCRIPTION
## PR Outline

This change resolves the Zorin OS install and launch path issues and is now working on Zorin OS. It improves install verification, standardizes wine-tkg usage across install/launch flows, and fixes vkd3d-proton D3D12 placement/overrides to prevent startup hangs.

Validation status: Single confirmation on Zorin OS, but full regression testing is still needed across all supported distributions before merge.

Review request: comments, revisions, and testing feedback are very welcome so we can safely merge this for Zorin users.

## Temporary _pr_notes_temp zorin testing notes (remove before merge)

Use this to track testing results and install issues specific to Zorin OS while validating this PR.
Please add reproduction steps, logs, and outcomes for any failures (installer flow, launcher command, WebView2
detection, D3D12/vkd3d behavior, and app launch stability), then remove before merge.

## Handy note: UI scaling

### Affinity: Change UI Scale
```code
WINEPREFIX=/home/blade/.AffinityLinux winecfg
```

Open Graphics in  winecfg  and adjust DPI/scaling as needed.